### PR TITLE
add signal for devices's address changing

### DIFF
--- a/src/device.h
+++ b/src/device.h
@@ -46,7 +46,7 @@ class BLUEZQT_EXPORT Device : public QObject
     Q_OBJECT
 
     Q_PROPERTY(QString ubi READ ubi)
-    Q_PROPERTY(QString address READ address)
+    Q_PROPERTY(QString address READ address NOTIFY addressChanged)
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
     Q_PROPERTY(QString friendlyName READ friendlyName NOTIFY friendlyNameChanged)
     Q_PROPERTY(QString remoteName READ remoteName NOTIFY remoteNameChanged)

--- a/src/device_p.cpp
+++ b/src/device_p.cpp
@@ -147,6 +147,8 @@ void DevicePrivate::propertiesChanged(const QString &interface, const QVariantMa
 
         if (property == QLatin1String("Name")) {
             namePropertyChanged(value.toString());
+        } else if (property == QLatin1String("Address")) {
+            addressPropertyChanged(value.toString());
         } else if (property == QLatin1String("Alias")) {
             aliasPropertyChanged(value.toString());
         } else if (property == QLatin1String("Class")) {
@@ -201,6 +203,14 @@ void DevicePrivate::namePropertyChanged(const QString &value)
         m_name = value;
         Q_EMIT q.data()->remoteNameChanged(m_name);
         Q_EMIT q.data()->friendlyNameChanged(q.data()->friendlyName());
+    }
+}
+
+void DevicePrivate::addressPropertyChanged(const QString &value)
+{
+    if (m_address != value) {
+        m_address = value;
+        Q_EMIT q.data()->addressChanged(m_address);
     }
 }
 

--- a/src/device_p.h
+++ b/src/device_p.h
@@ -53,6 +53,7 @@ public:
     void propertiesChanged(const QString &interface, const QVariantMap &changed, const QStringList &invalidated);
     void namePropertyChanged(const QString &value);
     void aliasPropertyChanged(const QString &value);
+    void addressPropertyChanged(const QString &value);
     void classPropertyChanged(quint32 value);
 
     QWeakPointer<Device> q;


### PR DESCRIPTION
If device connected with adapter via Bluetooth LE and i try to pair, device's address changing to another and it's address type becomes to 'public' instead of 'random'. So there is no possibility to control pairing result.